### PR TITLE
Install duperemove and fix inconsistencies

### DIFF
--- a/.github/workflows/snapshot-rawhide.yml
+++ b/.github/workflows/snapshot-rawhide.yml
@@ -1,7 +1,5 @@
 name: snapshot-rawhide
 on:
-  schedule:
-    - cron: "00 14 * * 1"
   workflow_dispatch: # allow manually triggering builds
 jobs:
   snapshot-rawhide:

--- a/config/scripts/regen-initramfs.sh
+++ b/config/scripts/regen-initramfs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -oue pipefail
 
-KVER="$(rpm -q kernel | sed -rn 's/^kernel-(.*)$/\1/p')"
+KVER="$(rpm -q kernel-core --qf '%{version}-%{release}.%{arch}' | head -n1)"
 ls -1 --zero /usr/lib/modules | grep -vz "^$KVER$" \
     | sed -z 's/[[:space:]]*$//' \
     | xargs -r -0 -- printf "/usr/lib/modules/%s\0" \

--- a/recipes/fedora-kinoite-laptop.yml
+++ b/recipes/fedora-kinoite-laptop.yml
@@ -41,11 +41,12 @@ modules:
   # We use a stable kernel instead of the one from rawhide
   - type: script
     snippets:
+      - rpm-ostree cliwrap install-to-root /
       - rpm-ostree override replace kernel-modules-core kernel-modules-extra kernel-core kernel-modules kernel-headers kernel --experimental --from repo=fedora-40-kernel
-      - rm -f /usr/lib/modules/*/initramfs.img
-      - /tmp/config/scripts/regen-initramfs.sh
-      - rm -rf /boot
-      - mkdir -m 755 /boot
+      #- rm -f /usr/lib/modules/*/initramfs.img
+      #- /tmp/config/scripts/regen-initramfs.sh
+      #- rm -rf /boot
+      #- mkdir -m 755 /boot
 
   # Package management
   - type: rpm-ostree
@@ -60,7 +61,7 @@ modules:
   - type: script
     snippets:
       - createrepo /usr/share/local-rpm-repo
-      - dnf5 '--exclude=kernel*' upgrade -y
+      #- dnf5 '--exclude=kernel*' upgrade -y
 
   # Virtualization
   - type: rpm-ostree
@@ -104,8 +105,8 @@ modules:
     snippets:
       # WORKAROUND: Create the group for 1Password with the a consistent GID
       # Also, 1Password requires the GID to be > 1000
-      - groupadd -g 5001 "onepassword"
-      - groupadd -g 5002 "onepassword-cli"
+      - echo "onepassword:x:5001:" >> /usr/lib/group
+      - echo "onepassword-cli:x:5002:" >> /usr/lib/group
 
   # Proprietary
   - type: rpm-ostree
@@ -126,6 +127,7 @@ modules:
   # CLI Utils
   - type: rpm-ostree
     install:
+      - duperemove
       - htop
       - mosh
       - ncdu
@@ -164,20 +166,29 @@ modules:
   # BUST LAYER CACHE IF THERE ARE UPDATES
   # We still download packages from whatever repo is suggested by Fedora's metalink
   # But we trust UWaterloo to be somewhat quickly up to date.
-  - type: containerfile
-    snippets:
-      - ADD https://mirror.csclub.uwaterloo.ca/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/repomd.xml /tmp/mirror-cache-bust
+  #- type: containerfile
+  #  snippets:
+  #    - ADD https://mirror.csclub.uwaterloo.ca/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/repomd.xml /tmp/mirror-cache-bust
 
   # Upgrade all in one layer if there are any new packages
-  - type: script
-    snippets:
-      - dnf5 '--exclude=kernel*' upgrade -y
-      # WORKAROUND: do last because my RPM depends on 1Password not ever being upgraded
-      - rpm-ostree install 1password-ostree-workaround
+  #- type: script
+  #  snippets:
+  #    - dnf5 '--exclude=kernel*' upgrade -y
 
-  # WORKAROUND: Put back /opt and merge /usr/etc into /etc
+  - type: rpm-ostree
+    install:
+      # WORKAROUND: do last because my RPM depends on 1Password not ever being upgraded
+      - 1password-ostree-workaround
+
   - type: script
     snippets:
+      # WORKAROUND: Ensure all accounts are moved to altfiles
+      - grep -Ev "(^root:)" /etc/passwd >> /usr/lib/passwd
+      - grep -Ev "(^root:)|(^wheel:)" /etc/group >> /usr/lib/group
+      - echo "root:x:0:0:root:/root:/bin/bash" > /etc/passwd
+      - echo "root:x:0:" > /etc/group
+      - echo "wheel:x:10:" >> /etc/group
+      #   Put back /opt and merge /usr/etc into /etc
       - rm /opt
       - ln -s var/opt /opt
       - cp -fal /usr/etc /

--- a/recipes/fedora-kinoite-laptop.yml
+++ b/recipes/fedora-kinoite-laptop.yml
@@ -41,12 +41,9 @@ modules:
   # We use a stable kernel instead of the one from rawhide
   - type: script
     snippets:
+      # the cliwrap `kernel-install` script will delete old /usr/lib/modules directories and regenerate our initramfs for us
       - rpm-ostree cliwrap install-to-root /
       - rpm-ostree override replace kernel-modules-core kernel-modules-extra kernel-core kernel-modules kernel-headers kernel --experimental --from repo=fedora-40-kernel
-      #- rm -f /usr/lib/modules/*/initramfs.img
-      #- /tmp/config/scripts/regen-initramfs.sh
-      #- rm -rf /boot
-      #- mkdir -m 755 /boot
 
   # Package management
   - type: rpm-ostree
@@ -103,10 +100,13 @@ modules:
 
   - type: script
     snippets:
-      # WORKAROUND: Create the group for 1Password with the a consistent GID
+      # WORKAROUND: Create the groups for 1Password with consistent GIDs because they chown files to these IDs
       # Also, 1Password requires the GID to be > 1000
+      # Needed because the rpm scriptlet itself doesn't specify these parameters.
       - echo "onepassword:x:5001:" >> /usr/lib/group
       - echo "onepassword-cli:x:5002:" >> /usr/lib/group
+      - echo "g onepassword 5001" > /usr/lib/sysusers.d/onepassword.conf
+      - echo "g onepassword-cli 5002" >> /usr/lib/sysusers.d/onepassword.conf
 
   # Proprietary
   - type: rpm-ostree
@@ -182,17 +182,18 @@ modules:
 
   - type: script
     snippets:
-      # WORKAROUND: Ensure all accounts are moved to altfiles
-      - grep -Ev "(^root:)" /etc/passwd >> /usr/lib/passwd
-      - grep -Ev "(^root:)|(^wheel:)" /etc/group >> /usr/lib/group
+      # clear accounts so they uid/gids get assigned by sysusers.d
       - echo "root:x:0:0:root:/root:/bin/bash" > /etc/passwd
       - echo "root:x:0:" > /etc/group
       - echo "wheel:x:10:" >> /etc/group
-      #   Put back /opt and merge /usr/etc into /etc
+      # Put back /opt and create symlinks in /var
       - rm /opt
       - ln -s var/opt /opt
+      - echo "L /var/opt/google - - - - ../../usr/lib/opt/google" > /usr/lib/tmpfiles.d/var-symlinks.conf
+      - echo "L /var/opt/1Password - - - - ../../usr/lib/opt/1Password" >> /usr/lib/tmpfiles.d/var-symlinks.conf
+      # merge /usr/etc into /etc otherwise ostree tar import is not consistent
       - cp -fal /usr/etc /
-      # Also clear boot again
+      # Virtualization packages install files in /boot we don't want
       - rm -rf /boot
       - mkdir -m 755 /boot
       # rpm-ostree creates /40-rpmostree-pkg-usermod-qemu-kvm.conf for some reason


### PR DESCRIPTION
- We move users/groups from /etc to /usr/lib
- We use rpm-ostree cliwrap for kernel-install instead of regen-initramfs.sh
- We prepare to write a custom libdnf5 script to do upgrades with rpm-ostree.