### PR TITLE
Use relative symlinks to workaround ostree-rs-ext bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,11 +62,11 @@ jobs:
         run: |
           mkdir -p /etc/containers
           echo '{}' > /etc/containers/auth.json
-          ln -s /etc/containers/auth.json /etc/ostree/auth.json
+          ln -sr /etc/containers/auth.json /etc/ostree/auth.json
           mkdir -p ~/.config/containers
-          ln -s /etc/containers/auth.json ~/.config/containers/auth.json
+          ln -sr /etc/containers/auth.json ~/.config/containers/auth.json
           mkdir -p ~/.docker
-          ln -s /etc/containers/auth.json ~/.docker/config.json
+          ln -sr /etc/containers/auth.json ~/.docker/config.json
           buildah login ghcr.io --authfile /etc/containers/auth.json -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
       - name: Get container manifest
         id: target-manifest

--- a/.github/workflows/upgrade-snapshots.yml
+++ b/.github/workflows/upgrade-snapshots.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           mkdir -p /etc/containers
           echo '{}' > /etc/containers/auth.json
-          ln -s /etc/containers/auth.json /etc/ostree/auth.json
+          ln -sr /etc/containers/auth.json /etc/ostree/auth.json
           mkdir -p ~/.config/containers
-          ln -s /etc/containers/auth.json ~/.config/containers/auth.json
+          ln -sr /etc/containers/auth.json ~/.config/containers/auth.json
           mkdir -p ~/.docker
-          ln -s /etc/containers/auth.json ~/.docker/config.json
+          ln -sr /etc/containers/auth.json ~/.docker/config.json
           buildah login ghcr.io --authfile /etc/containers/auth.json -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
See containers/bootc#679.
Rawhide might package a version with this bug so use relative symlinks for now.